### PR TITLE
Change `ndrange` to `CartesianIndices`

### DIFF
--- a/scripts/example_2d.jl
+++ b/scripts/example_2d.jl
@@ -39,15 +39,11 @@ function main(; device)
 
     test! = Kernel(kernel_test_2d!, device)
 
-    sleep(1) # workaround to aviod synchronize device
+    TinyKernels.device_synchronize(device)
     for i in 1:100
         println("  step $i")
-        inner_event = test!(view(A, ranges[1]...),
-                            view(B, ranges[1]...),
-                            view(C, ranges[1]...), s; range=length.(ranges[1]))
-        outer_events = [test!(view(A, ranges[i]...),
-                              view(B, ranges[i]...),
-                              view(C, ranges[i]...), s; range=length.(ranges[i]), priority=:high) for i in 2:lastindex(ranges)]
+        inner_event  =  test!(A,B,C,s; ndrange=ranges[1])
+        outer_events = [test!(A,B,C,s; ndrange=ranges[i], priority=:high) for i in 2:lastindex(ranges)]
 
         wait(outer_events)
         # sleep(1/30)

--- a/scripts/example_3d.jl
+++ b/scripts/example_3d.jl
@@ -41,15 +41,11 @@ function main(; device)
 
     test! = Kernel(kernel_test_3d!, device)
 
-    sleep(1) # workaround to aviod synchronize device
+    TinyKernels.device_synchronize(device)
     for i in 1:100
         println("  step $i")
-        inner_event = test!(view(A, ranges[1]...),
-                            view(B, ranges[1]...),
-                            view(C, ranges[1]...), s; range=length.(ranges[1]))
-        outer_events = [test!(view(A, ranges[i]...),
-                              view(B, ranges[i]...),
-                              view(C, ranges[i]...), s; range=length.(ranges[i]), priority=:high) for i in 2:lastindex(ranges)]
+        inner_event  =  test!(A,B,C,s; ndrange=ranges[1])
+        outer_events = [test!(A,B,C,s; ndrange=ranges[i], priority=:high) for i in 2:lastindex(ranges)]
 
         wait(outer_events)
         # sleep(1/30)

--- a/scripts/example_ad_2d.jl
+++ b/scripts/example_ad_2d.jl
@@ -39,9 +39,9 @@ function main(; device)
     dA = copy(A); fill!(dA,1.0)
     dB = copy(A)
 
-    sleep(1)
+    TinyKernels.device_synchronize(device)
 
-    wait(grad_test_kernel!(DuplicatedNoNeed(A, dA), DuplicatedNoNeed(B, dB), Const(C), Const(s); range=size(A)))
+    wait(grad_test_kernel!(DuplicatedNoNeed(A, dA), DuplicatedNoNeed(B, dB), Const(C), Const(s); ndrange=size(A)))
 
     return
 end

--- a/scripts/test_ad_2d.jl
+++ b/scripts/test_ad_2d.jl
@@ -56,13 +56,13 @@ function main(; device)
     # Generate kernel gradient
     grad_test_kernel! = Enzyme.autodiff(test!)
     # Evaluate forward problem
-    sleep(1)
-    wait(test!(RUx, RUy, Ux, Uy; range=size(Ux)))
+    TinyKernels.device_synchronize(device)
+    wait(test!(RUx, RUy, Ux, Uy; ndrange=size(Ux)))
     # Compute VJP
     wait(grad_test_kernel!(DuplicatedNoNeed(RUx, ∂Rx_∂R),
                            DuplicatedNoNeed(RUy, ∂Ry_∂R),
                            DuplicatedNoNeed(Ux , ∂Ux_∂R),
-                           DuplicatedNoNeed(Uy , ∂Uy_∂R); range=size(Ux)))
+                           DuplicatedNoNeed(Uy , ∂Uy_∂R); ndrange=size(Ux)))
     @assert ∂Ux_∂R ≈ ∂Ux_∂R_exact
     @assert ∂Uy_∂R ≈ ∂Uy_∂R_exact
     return

--- a/src/TinyKernels.jl
+++ b/src/TinyKernels.jl
@@ -1,6 +1,6 @@
 module TinyKernels
 
-export Kernel, @tiny, @indices, device_array
+export Kernel, @tiny, @indices, @linearindex, @cartesianindex, device_array, device_synchronize
 
 struct Kernel{BackendType,Fun}
     fun::Fun
@@ -10,14 +10,13 @@ Kernel(fun, ::BackendType) where {BackendType} = Kernel{BackendType,typeof(fun)}
 
 Base.similar(::Kernel{BE}, f::F) where {BE,F} = Kernel{BE,F}(f)
 
-function __get_indices end
-
-include("macros.jl")
-
-@inline __validindex(ndrange) = CartesianIndex(__get_indices(Val(ndims(ndrange)))) ∈ ndrange
-
 function device_array end
 
+function device_synchronize end
+
+function __get_index end
+
+include("macros.jl")
 
 include("cuda_backend.jl")
 

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,15 +1,20 @@
 import MacroTools: splitdef, combinedef
 
+@inline __validindex(ndrange) = __get_index() <= length(ndrange)
+
 macro tiny(expr)
     def = splitdef(expr)
     # create GPU kernel
     pushfirst!(def[:args], :__ndrange__)
     def[:body] = quote
-        if TinyKernels.__validindex(__ndrange__)
-            $(def[:body])
+        if !TinyKernels.__validindex(__ndrange__)
+            return
         end
+        $(def[:body])
     end
     return esc(combinedef(def))
 end
 
-macro indices() esc(:(TinyKernels.__get_indices(Val(ndims(__ndrange__))))) end
+macro indices()        esc(:( @inbounds         Tuple( __ndrange__[TinyKernels.__get_index()]) )) end
+macro linearindex()    esc(:( @inbounds LinearIndices(__ndrange__)[TinyKernels.__get_index()]  )) end
+macro cartesianindex() esc(:( @inbounds                __ndrange__[TinyKernels.__get_index()]  )) end


### PR DESCRIPTION
This PR replaces `range` keyword with `ndrange` keyword, and now the user can pass anything that could be converted to `CartesianIndices` as `ndrange`. `@indices` macro now converts to `NTuple` the `CartesianIndex` generated by indexing this `ndrange` using the 1D index.