### PR TITLE
Fix Enzyme support for CPU

### DIFF
--- a/src/kernel_AD.jl
+++ b/src/kernel_AD.jl
@@ -1,12 +1,23 @@
 module KernelAD
 
 import Enzyme
-import TinyKernels: Kernel
 
-function Enzyme.autodiff(kernel::Kernel{<:Any, Fun}) where Fun
+import TinyKernels: Kernel, GPUDevice
+import TinyKernels.CPUBackend: CPUDevice
+
+function Enzyme.autodiff(kernel::Kernel{<:GPUDevice, Fun}) where Fun
     fun = kernel.fun
     function df(ctx, args...)
         Enzyme.autodiff_deferred(fun::Fun, Enzyme.Const, ctx, args...)
+        return nothing
+    end
+    similar(kernel, df)
+end
+
+function Enzyme.autodiff(kernel::Kernel{<:CPUDevice, Fun}) where Fun
+    fun = kernel.fun
+    function df(ctx, args...)
+        Enzyme.autodiff(Enzyme.Reverse, fun::Fun, Enzyme.Const, ctx, args...)
         return nothing
     end
     similar(kernel, df)


### PR DESCRIPTION
Adds CPU dispatch for the `Enzyme.autodiff` function overload in TinyKernels.